### PR TITLE
moving production dependencies out of devDependencies node

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,13 @@
   "engines": {
     "node": ">= 0.8.0"
   },
-  "devDependencies": {
-    "chai": "~1.8.1",
+  "dependencies": {
     "event-stream": "~3.0.20",
     "gulp": "~3.1.4",
-    "js-beautify": "~1.4.2",
+    "js-beautify": "~1.4.2"    
+  },
+  "devDependencies": {
+    "chai": "~1.8.1",
     "mocha": "~1.16.1"
   },
   "keywords": [


### PR DESCRIPTION
When adding gulp-prettify as a production dependency, there are currently 2 modules that aren't pulled down automatically. 
