### PR TITLE
js-beautify version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-prettify",
   "description": "Prettify, format, beautify HTML.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "homepage": "https://github.com/jonschlinkert/gulp-prettify",
   "author": {
     "name": "Jon Schlinkert",


### PR DESCRIPTION
Bumped the js-beautify version to 1.5.1
The previous version would mangle angular.js inline templates.
Tests are still passing.
